### PR TITLE
Case-insensitive securityScheme (fixes #96)

### DIFF
--- a/aiopenapi3/v30/glue.py
+++ b/aiopenapi3/v30/glue.py
@@ -86,8 +86,7 @@ class Request(RequestBase):
 
         value = cast(str, value)
         if ss.type == "http" and ss.scheme_ == "bearer":
-            header = ss.bearerFormat or "Bearer {}"
-            self.req.headers["Authorization"] = header.format(value)
+            self.req.headers["Authorization"] = "Bearer {}".format(value)
 
         if ss.type == "mutualTLS":
             # TLS Client certificates (mutualTLS)

--- a/aiopenapi3/v30/security.py
+++ b/aiopenapi3/v30/security.py
@@ -1,6 +1,6 @@
 from typing import Optional, Dict, List
 
-from pydantic import Field, root_validator, BaseModel
+from pydantic import BaseModel, constr, Field, root_validator
 
 from ..base import ObjectExtended
 
@@ -42,7 +42,7 @@ class SecurityScheme(ObjectExtended):
     description: Optional[str] = Field(default=None)
     name: Optional[str] = Field(default=None)
     in_: Optional[str] = Field(default=None, alias="in")
-    scheme_: Optional[str] = Field(default=None, alias="scheme")
+    scheme_: Optional[constr(to_lower=True)] = Field(default=None, alias="scheme", )
     bearerFormat: Optional[str] = Field(default=None)
     flows: Optional[OAuthFlows] = Field(default=None)
     openIdConnectUrl: Optional[str] = Field(default=None)

--- a/aiopenapi3/v30/security.py
+++ b/aiopenapi3/v30/security.py
@@ -42,7 +42,7 @@ class SecurityScheme(ObjectExtended):
     description: Optional[str] = Field(default=None)
     name: Optional[str] = Field(default=None)
     in_: Optional[str] = Field(default=None, alias="in")
-    scheme_: Optional[constr(to_lower=True)] = Field(default=None, alias="scheme", )
+    scheme_: Optional[constr(to_lower=True)] = Field(default=None, alias="scheme")
     bearerFormat: Optional[str] = Field(default=None)
     flows: Optional[OAuthFlows] = Field(default=None)
     openIdConnectUrl: Optional[str] = Field(default=None)

--- a/aiopenapi3/v31/security.py
+++ b/aiopenapi3/v31/security.py
@@ -1,6 +1,6 @@
 from typing import Optional, Dict, List
 
-from pydantic import Field, root_validator, BaseModel
+from pydantic import Field, root_validator, BaseModel, constr
 
 from ..base import ObjectExtended
 
@@ -42,7 +42,7 @@ class SecurityScheme(ObjectExtended):
     description: Optional[str] = Field(default=None)
     name: Optional[str] = Field(default=None)
     in_: Optional[str] = Field(default=None, alias="in")
-    scheme_: Optional[str] = Field(default=None, alias="scheme")
+    scheme_: Optional[constr(to_lower=True)] = Field(default=None, alias="scheme")
     bearerFormat: Optional[str] = Field(default=None)
     flows: Optional[OAuthFlows] = Field(default=None)
     openIdConnectUrl: Optional[str] = Field(default=None)


### PR DESCRIPTION
- Converts SecurityScheme._scheme to lowercase using pedantic
- Does not use (or make assumptions for) the bearerFormat string in the security scheme

Tested with openapi v3 spec having component.securitySchemes[].scheme="Bearer" and having .bearerFormat="JWT", which both prevented successful authorisation prior to this patch.