### PR TITLE
Return expected non-json responses on OpenAPI 3.0

### DIFF
--- a/aiopenapi3/v30/glue.py
+++ b/aiopenapi3/v30/glue.py
@@ -432,8 +432,11 @@ class Request(RequestBase):
             ).unmarshalled
             return rheaders, data
         else:
-            # We have received a valid (i.e. expected) content type,
-            # but we can't validate it since it's not json.
+            """
+            We have received a valid (i.e. expected) content type,
+            e.g. application/octet-stream
+            but we can't validate it since it's not json.
+            """
             return rheaders, ctx.received
 
 

--- a/aiopenapi3/v30/glue.py
+++ b/aiopenapi3/v30/glue.py
@@ -432,7 +432,9 @@ class Request(RequestBase):
             ).unmarshalled
             return rheaders, data
         else:
-            raise NotImplementedError()
+            # We have received a valid (i.e. expected) content type,
+            # but we can't validate it since it's not json.
+            return rheaders, ctx.received
 
 
 class AsyncRequest(Request, AsyncRequestBase):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -267,6 +267,11 @@ def with_paths_response_header(openapi_version):
 
 
 @pytest.fixture
+def with_paths_response_content_type_octet():
+    yield _get_parsed_yaml("paths-response-content-type-octet.yaml")
+
+
+@pytest.fixture
 def with_paths_response_header_v20():
     yield _get_parsed_yaml("paths-response-header-v20.yaml")
 

--- a/tests/fixtures/paths-response-content-type-octet.yaml
+++ b/tests/fixtures/paths-response-content-type-octet.yaml
@@ -1,0 +1,38 @@
+openapi: 3.0.3
+info:
+  title: ''
+  version: 0.0.0
+servers:
+  - url: http://127.0.0.1/api
+
+security:
+  - {}
+
+paths:
+  /octet/headers:
+    get:
+      operationId: header
+      responses:
+        200:
+          description: "ok"
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: byte
+          headers:
+            X-required:
+              required: true
+              schema:
+                type: string
+  /octet:
+    get:
+      operationId: octet
+      responses:
+        200:
+          description: "ok"
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: byte

--- a/tests/path_test.py
+++ b/tests/path_test.py
@@ -352,6 +352,20 @@ def test_paths_response_header(httpx_mock, with_paths_response_header):
     return
 
 
+def test_paths_response_content_type_octet(httpx_mock, with_paths_response_content_type_octet):
+    CONTENT = b"\x00\x11"
+    httpx_mock.add_response(headers={"Content-Type": "application/octet-stream", "X-required": "1"}, content=CONTENT)
+    api = OpenAPI(URLBASE, with_paths_response_content_type_octet, session_factory=httpx.Client)
+    headers, data = api._.header(return_headers=True)
+    assert isinstance(headers["X-required"], str)
+    assert data == CONTENT
+    request = httpx_mock.get_requests()[-1]
+
+    data = api._.octet()
+    assert data == CONTENT
+    request = httpx_mock.get_requests()[-1]
+
+
 def test_paths_tags(httpx_mock, with_paths_tags):
     import copy
 


### PR DESCRIPTION
For OpenAPI 3.0 schemas, non-json responses are returned (without validation) if the content-type is of an expected type. Matches the behaviour of OpenAPI 2.0. Fixes #108.