### PR TITLE
model - discriminated unions with parent properties

### DIFF
--- a/aiopenapi3/model.py
+++ b/aiopenapi3/model.py
@@ -155,6 +155,12 @@ class Model:  # (BaseModel):
             else:
                 classinfo.root = _t
         elif type == "object":
+            # this is a anyOf/oneOf - the parent may have properties which will collide with __root__
+            # so - add the parent properties to this model
+            if extra:
+                Model.annotationsof(extra, discriminators, schemanames, classinfo)
+                Model.fieldof(extra, classinfo)
+
             if hasattr(schema, "anyOf") and schema.anyOf:
                 assert all(schema.anyOf)
                 t = tuple(
@@ -229,11 +235,6 @@ class Model:  # (BaseModel):
                         Model.annotationsof(i, discriminators, schemanames, classinfo, fwdref=True)
                         Model.fieldof(i, classinfo)
 
-            # this is a anyOf/oneOf - the parent may have properties which will collide with __root__
-            # so - add the parent properties to this model
-            if extra:
-                Model.annotationsof(extra, discriminators, schemanames, classinfo)
-                Model.fieldof(extra, classinfo)
         elif type == "array":
             classinfo.root = Model.typeof(schema, _type="array")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -308,6 +308,11 @@ def with_schema_discriminated_union_warning(openapi_version):
 
 
 @pytest.fixture
+def with_schema_discriminated_union_merge(openapi_version):
+    yield _get_parsed_yaml("schema-discriminated-union-merge.yaml", openapi_version)
+
+
+@pytest.fixture
 def with_schema_discriminated_union_discriminator_name(openapi_version):
     yield _get_parsed_yaml("schema-discriminated-union-discriminator-name.yaml", openapi_version)
 

--- a/tests/fixtures/schema-discriminated-union-merge.yaml
+++ b/tests/fixtures/schema-discriminated-union-merge.yaml
@@ -1,0 +1,36 @@
+openapi: "3.1.0"
+info:
+  version: 1.0.0
+  title: enum test
+
+components:
+  schemas:
+    CustomContextVariable:
+      additionalProperties: false
+      discriminator:
+        mapping:
+          user: '#/components/schemas/UserContextVariable'
+        propertyName: type
+      oneOf:
+      - $ref: '#/components/schemas/UserContextVariable'
+      properties:
+        type:
+          description: Type of custom context variable.
+          type: string
+      required:
+      - type
+      type: object
+    UserContextVariable:
+      description: A [user](https://developer.atlassian.com/cloud/jira/platform/jira-expressions-type-reference#user)
+        specified as an Atlassian account ID.
+      properties:
+        accountId:
+          description: The account ID of the user.
+          type: string
+        type:
+          description: Type of custom context variable.
+          type: string
+      required:
+      - accountId
+      - type
+      type: object

--- a/tests/schema_test.py
+++ b/tests/schema_test.py
@@ -346,6 +346,15 @@ def test_schema_discriminated_union_warnings(with_schema_discriminated_union_war
             api = OpenAPI("/", s)
 
 
+def test_schema_discriminated_union_merge(with_schema_discriminated_union_merge, openapi_version):
+    from aiopenapi3.errors import DiscriminatorWarning
+
+    with pytest.warns(
+        DiscriminatorWarning, match=r"Discriminated Union member \S+ without const/enum key property \S+"
+    ):
+        api = OpenAPI("/", with_schema_discriminated_union_merge)
+
+
 def test_schema_discriminated_union_deep(with_schema_discriminated_union_deep):
     api = OpenAPI("/", with_schema_discriminated_union_deep)
     Dog = api.components.schemas["Dog"].get_type()


### PR DESCRIPTION
apply parent properties first, so children can overwrite the discriminator with their Literal value