### PR TITLE
license - restore BSD-3-Clause

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
 ]
 requires-python = ">=3.8"
 readme = "README.md"
-license = {text = "MIT"}
+license = {text = "BSD-3-Clause"}
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Environment :: Web Environment",


### PR DESCRIPTION
Dorthu/openapi3 had "BSD 3-Clause License" in setup.py migrating to setup.cfg license was left empty
migrating to pyproject.toml license was changed to MIT