### PR TITLE
Dropping 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     'typing_extensions; python_version<"3.10"',
     "jmespath",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 readme = "README.md"
 license = {text = "BSD-3-Clause"}
 classifiers = [


### PR DESCRIPTION
pyproject - require >= 3.9