### PR TITLE
docs - fix sphinx.ext.autodoc

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -151,3 +151,7 @@ https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#sections
     ^ for subsubsections
     " for paragraphs
 """
+
+# Sphinx autodoc contaminates pydantic BaseModel annotations, breaking extra="allow"
+# https://github.com/sphinx-doc/sphinx/issues/14337
+autodoc_use_legacy_class_based = True


### PR DESCRIPTION
* Python version:   3.14.0 (CPython)
* Sphinx version:   9.1.0
* Docutils version: 0.22.4
* Jinja2 version:   3.1.6
* Pygments version: 2.20.0

…
```
      File "/home/docs/checkouts/readthedocs.org/user_builds/aiopenapi3/envs/latest/lib/python3.14/site-packages/pydantic/_internal/_generate_schema.py", line 826, in _model_schema
        raise PydanticSchemaGenerationError(
            'The type annotation for `__pydantic_extra__` must be `dict[str, ...]`'
        )
    pydantic.errors.PydanticSchemaGenerationError: The type annotation for `__pydantic_extra__` must be `dict[str, ...]`
    
```

c.f. https://github.com/sphinx-doc/sphinx/issues/14337    